### PR TITLE
Add STREAM variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 client_secrets.json
 request.token
 .DS_Store
+/tests/

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -37,6 +37,10 @@ function getStreamInfo() {
 
 while true; do
 	STREAMER_NAME=$TWITCH_USER                                            #! Dont change this.
+	API_CALLS="false"                                                     #? Enable if you want to fetch stream metadata like the Title or Game. You can use the folowing variables with this enabled: $STREAMER_TITLE and $STREAMER_GAME.
+	if [[ "$API_CALLS" == "true" ]]; then                                 #
+		getStreamInfo $STREAMER_NAME STREAMER_TITLE STREAMER_GAME            #
+	fi                                                                    #
 	TIME_DATE=[$(date +"%m.%d.%y")]                                       # Preview example: [08.10.21]
 	VIDEO_VISIBILITY="unlisted"                                           #* Options: unlisted, private, public
 	VIDEO_DESCRIPTION="Uploaded using https://github.com/jenslys/AutoVOD" # YouTube video description.
@@ -45,10 +49,6 @@ while true; do
 	VIDEO_PLAYLIST="$STREAMER_NAME VODs"                                  # Playlist to upload to.
 	SPLIT_INTO_PARTS="false"                                              #? If you want to split the video into parts, set this to true. (if this is enabled VIDEO_DURATION is ignored).
 	SPLIT_VIDEO_DURATION="06:00:00"                                       # Duration of each part. (XX:XX:XX)
-	API_CALLS="false"                                                     #? Enable if you want to fetch stream metadata like the Title or Game. You can use the folowing variables with this enabled: $STREAMER_TITLE and $STREAMER_GAME.
-	if [[ "$API_CALLS" == "true"]]; then
-		getStreamInfo $STREAMER_NAME STREAMER_TITLE STREAMER_GAME
-	fi
 
 	# Splitting the stream into parts (If enabled)
 	if [[ "$SPLIT_INTO_PARTS" == "true" ]]; then

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -8,6 +8,17 @@ echo ""
 # Every minute, try to download the Twitch stream, and send it to YouTube.
 # Everything through the pipe, no video file is created.
 
+function getStreamTitle() {
+	json=$(curl -s https://twitch-api-wrapper.vercel.app/title/$1) # https://github.com/jenslys/twitch-api-wrapper
+	if [ "$json" = "[]" ]; then
+		echo "Stream is offline"
+	elif [ "$json" = "Too many requests, please try again later." ]; then
+		echo "Too many API requests"
+	else
+		echo "$json" | jq -r '.streamTitle'
+	fi
+}
+
 while true; do
 	STREAMER_NAME=$TWITCH_USER                                            #! Dont change this.
 	TIME_DATE=[$(date +"%m.%d.%y")]                                       # Preview example: [08.10.21]
@@ -17,7 +28,8 @@ while true; do
 	VIDEO_DURATION="12:00:00"                                             # XX:XX:XX (YouTube has a upload limit of 12 hours per video).
 	VIDEO_PLAYLIST="$STREAMER_NAME VODs"                                  # Playlist to upload to.
 	SPLIT_INTO_PARTS="false"                                              # If you want to split the video into parts, set this to true. (if this is enabled VIDEO_DURATION is ignored).
-	SPLIT_VIDEO_DURATION="06:00:00"
+	SPLIT_VIDEO_DURATION="06:00:00"                                       # Duration of each part. (XX:XX:XX)
+	STREAM_TITLE=$(getStreamTitle "$STREAMER_NAME")                       #* Optional variable you can add to VIDEO_TITLE if you want to display the stream title.
 
 	# Splitting the stream into parts (If enabled)
 	if [[ "$SPLIT_INTO_PARTS" == "true" ]]; then

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -46,7 +46,7 @@ while true; do
 	SPLIT_INTO_PARTS="false"                                              #? If you want to split the video into parts, set this to true. (if this is enabled VIDEO_DURATION is ignored).
 	SPLIT_VIDEO_DURATION="06:00:00"                                       # Duration of each part. (XX:XX:XX)
 	API_CALLS="false"                                                     #? Enable if you want to fetch stream metadata like the Title or Game. You can use the folowing variables with this enabled: $STREAMER_TITLE and $STREAMER_GAME.
-	if [[API_CALLS == "true"]]; then
+	if [[$API_CALLS == "true"]]; then
 		getStreamInfo $STREAMER_NAME STREAMER_TITLE STREAMER_GAME
 	fi
 

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -20,7 +20,14 @@ function getStreamTitle() {
 }
 
 function getStreamGame() {
-	#! Not implemented yet.
+	json=$(curl -s https://twitch-api-wrapper.vercel.app/game/$1) # https://github.com/jenslys/twitch-api-wrapper
+	if [ "$json" = "[]" ]; then
+		echo "Stream is offline"
+	elif [ "$json" = "Too many requests, please try again later." ]; then
+		echo "Too many API requests"
+	else
+		echo "$json" | jq -r '.streamGame'
+	fi
 }
 
 while true; do
@@ -34,9 +41,9 @@ while true; do
 	SPLIT_INTO_PARTS="false"                                              # If you want to split the video into parts, set this to true. (if this is enabled VIDEO_DURATION is ignored).
 	SPLIT_VIDEO_DURATION="06:00:00"                                       # Duration of each part. (XX:XX:XX)
 	API_CALLS="false"                                                     # Enable this if you want to use more stream metadata like STREAM_TITLE and STREAM_GAME. (This is a boolean value, because we dont want to make unnecessary API calls. if variables are not used)
-	if [[API_CALLS == "true"]]; then                                      #? If API_CALLS is enabled.
-		STREAM_TITLE=$(getStreamTitle "$STREAMER_NAME")                      #* Optional variable you can add to VIDEO_TITLE if you want to display the stream title.
-		STREAM_GAME=""                                                       #* Not implemented yet.
+	if [[API_CALLS == "true"]]; then                                      #
+		STREAM_TITLE=$(getStreamTitle "$STREAMER_NAME")                      #* Optional variable you can add to display the current stream title.
+		STREAM_GAME=$(getStreamGame "$STREAMER_NAME")                        #* Optioanl variable you can add to display the current stream game.
 	fi
 
 	# Splitting the stream into parts (If enabled)

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -46,7 +46,7 @@ while true; do
 	SPLIT_INTO_PARTS="false"                                              #? If you want to split the video into parts, set this to true. (if this is enabled VIDEO_DURATION is ignored).
 	SPLIT_VIDEO_DURATION="06:00:00"                                       # Duration of each part. (XX:XX:XX)
 	API_CALLS="false"                                                     #? Enable if you want to fetch stream metadata like the Title or Game. You can use the folowing variables with this enabled: $STREAMER_TITLE and $STREAMER_GAME.
-	if [[$API_CALLS == "true"]]; then
+	if [[ "$API_CALLS" == "true"]]; then
 		getStreamInfo $STREAMER_NAME STREAMER_TITLE STREAMER_GAME
 	fi
 

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -15,7 +15,7 @@ function getStreamTitle() {
 	elif [ "$json" = "Too many requests, please try again later." ]; then
 		echo "Too many API requests"
 	else
-		echo "$json" | jq -r '.streamTitle'
+		echo "$json" | jq -r '.stream_title'
 	fi
 }
 
@@ -26,7 +26,7 @@ function getStreamGame() {
 	elif [ "$json" = "Too many requests, please try again later." ]; then
 		echo "Too many API requests"
 	else
-		echo "$json" | jq -r '.streamGame'
+		echo "$json" | jq -r '.stream_game'
 	fi
 }
 

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -7,9 +7,10 @@ echo ""
 
 # Every minute, try to download the Twitch stream, and send it to YouTube.
 # Everything through the pipe, no video file is created.
+# Src for API wrapper: # https://github.com/jenslys/twitch-api-wrapper
 
 function getStreamTitle() {
-	json=$(curl -s https://twitch-api-wrapper.vercel.app/title/$1) # https://github.com/jenslys/twitch-api-wrapper
+	json=$(curl -s https://twitch-api-wrapper.vercel.app/title/$1)
 	if [ "$json" = "[]" ]; then
 		echo "Stream is offline"
 	elif [ "$json" = "Too many requests, please try again later." ]; then
@@ -20,7 +21,7 @@ function getStreamTitle() {
 }
 
 function getStreamGame() {
-	json=$(curl -s https://twitch-api-wrapper.vercel.app/game/$1) # https://github.com/jenslys/twitch-api-wrapper
+	json=$(curl -s https://twitch-api-wrapper.vercel.app/game/$1)
 	if [ "$json" = "[]" ]; then
 		echo "Stream is offline"
 	elif [ "$json" = "Too many requests, please try again later." ]; then

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -61,7 +61,7 @@ while true; do
 		fi
 	fi
 
-	STREAMLINK_OPTIONS="best --hls-duration $VIDEO_DURATION --twitch-disable-hosting --twitch-disable-reruns -O --loglevel error" # https://streamlink.github.io/cli.html#twitch
+	STREAMLINK_OPTIONS="best --hls-duration $VIDEO_DURATION --twitch-disable-hosting --twitch-disable-ads --twitch-disable-reruns -O --loglevel error" # https://streamlink.github.io/cli.html#twitch
 
 	echo "Checking twitch.tv/$STREAMER_NAME for a stream."
 

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -10,22 +10,22 @@ echo ""
 # Src for API wrapper: # https://github.com/jenslys/twitch-api-wrapper
 
 function getStreamTitle() {
-	json=$(curl -s https://twitch-api-wrapper.vercel.app/title/$1)
+	json=$(curl -s --retry 5 --retry-delay 2 --connect-timeout 30 https://twitch-api-wrapper.vercel.app/title/$1)
 	if [ "$json" = "[]" ]; then
 		echo "Stream is offline"
 	elif [ "$json" = "Too many requests, please try again later." ]; then
-		echo "Too many API requests"
+		echo $json
 	else
 		echo "$json" | jq -r '.stream_title'
 	fi
 }
 
 function getStreamGame() {
-	json=$(curl -s https://twitch-api-wrapper.vercel.app/game/$1)
+	json=$(curl -s --retry 5 --retry-delay 2 --connect-timeout 30 https://twitch-api-wrapper.vercel.app/game/$1)
 	if [ "$json" = "[]" ]; then
 		echo "Stream is offline"
 	elif [ "$json" = "Too many requests, please try again later." ]; then
-		echo "Too many API requests"
+		$json
 	else
 		echo "$json" | jq -r '.stream_game'
 	fi

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -11,10 +11,8 @@ function getStreamInfo() {
 
 	echo "Fetching stream metadata..."
 	echo ""
-
 	url="https://twitch-api-wrapper.vercel.app/info/$1"
 	json=$(curl -s --retry 5 --retry-delay 2 --connect-timeout 30 $url)
-
 	if [ "$json" = "Too many requests, please try again later." ]; then
 		echo $json
 		echo ""

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -19,6 +19,10 @@ function getStreamTitle() {
 	fi
 }
 
+function getStreamGame() {
+	#! Not implemented yet.
+}
+
 while true; do
 	STREAMER_NAME=$TWITCH_USER                                            #! Dont change this.
 	TIME_DATE=[$(date +"%m.%d.%y")]                                       # Preview example: [08.10.21]
@@ -29,7 +33,11 @@ while true; do
 	VIDEO_PLAYLIST="$STREAMER_NAME VODs"                                  # Playlist to upload to.
 	SPLIT_INTO_PARTS="false"                                              # If you want to split the video into parts, set this to true. (if this is enabled VIDEO_DURATION is ignored).
 	SPLIT_VIDEO_DURATION="06:00:00"                                       # Duration of each part. (XX:XX:XX)
-	STREAM_TITLE=$(getStreamTitle "$STREAMER_NAME")                       #* Optional variable you can add to VIDEO_TITLE if you want to display the stream title.
+	API_CALLS="false"                                                     # Enable this if you want to use more stream metadata like STREAM_TITLE and STREAM_GAME. (This is a boolean value, because we dont want to make unnecessary API calls. if variables are not used)
+	if [[API_CALLS == "true"]]; then                                      #? If API_CALLS is enabled.
+		STREAM_TITLE=$(getStreamTitle "$STREAMER_NAME")                      #* Optional variable you can add to VIDEO_TITLE if you want to display the stream title.
+		STREAM_GAME=""                                                       #* Not implemented yet.
+	fi
 
 	# Splitting the stream into parts (If enabled)
 	if [[ "$SPLIT_INTO_PARTS" == "true" ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.14
 
 # Upgrade the system and install dependencies
 
-RUN	apk add --no-cache --upgrade python3 tar wget bash
+RUN	apk add --no-cache --upgrade python3 tar wget bash jq
 RUN	python3 -m ensurepip
 
 RUN 	pip3 install --upgrade streamlink 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ apt-get install python3-pip tar
 pip3 install --upgrade streamlink
 ```
 
+### JQ
+
+```bash
+apt-get install jq
+```
+
 #### YouTubeUploader
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ apt-get install python3-pip tar
 pip3 install --upgrade streamlink
 ```
 
-### JQ
+#### JQ
 
 ```bash
 apt-get install jq

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ apt-get install jq
 ```bash
 wget https://github.com/porjo/youtubeuploader/releases/download/22.03/youtubeuploader_22.03_Linux_x86_64.tar.gz
 tar -xvf youtubeuploader_22.03_Linux_x86_64.tar.gz && rm youtubeuploader_22.03_Linux_x86_64.tar.gz
-mv youtubeuploader_22.03_Linux_x86_64 /usr/local/bin/youtubeuploader
+mv youtubeuploader /usr/local/bin/youtubeuploader
 ```
 
 #### AutoVOD
@@ -92,7 +92,7 @@ Set up your credentials to allow YouTubeUploader to upload videos to YouTube.
         youtubeuploader -filename sample.mp4
         ```
 
-    1. and then simply copy the token file along with `youtubeuploader` and `client_secrets.json` to the remote host.
+    1. and then simply copy the token file along with `youtubeuploader` and `client_secrets.json` to the remote host. make sure these are placed inside the autovod folder
 
 **Note**
 To be able to upload videos as either "Unlisted or Public", you will have to request an [API audit](https://support.google.com/youtube/contact/yt_api_form) from YouTube for your project. Without an audit your videos will be locked as private.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Set up your credentials to allow YouTubeUploader to upload videos to YouTube.
         youtubeuploader -filename sample.mp4
         ```
 
-    1. and then simply copy the token file along with `youtubeuploader` and `client_secrets.json` to the remote host. make sure these are placed inside the autovod folder
+    1. and then simply copy the token file along with `youtubeuploader` and `client_secrets.json` to the remote host. Make sure these are placed inside the 'autovod' folder
 
 **Note**
 To be able to upload videos as either "Unlisted or Public", you will have to request an [API audit](https://support.google.com/youtube/contact/yt_api_form) from YouTube for your project. Without an audit your videos will be locked as private.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Set up your credentials to allow YouTubeUploader to upload videos to YouTube.
     1. and then simply copy the token file along with `youtubeuploader` and `client_secrets.json` to the remote host. Make sure these are placed inside the 'autovod' folder
 
 **Note**
-To be able to upload videos as either "Unlisted or Public", you will have to request an [API audit](https://support.google.com/youtube/contact/yt_api_form) from YouTube for your project. Without an audit your videos will be locked as private.
+To be able to upload videos as either "Unlisted or Public" and upload multiple videos a day, you will have to request an [API audit](https://support.google.com/youtube/contact/yt_api_form) from YouTube. Without an audit your videos will be locked as private and you are limited to how many videos you can upload before you reach a quota.
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ printf "${g}[$now] Updating and upgrading packages...${c}\n"
 apt-get -qq update && apt-get -qq upgrade
 
 printf "${g}[$now] Installing Packages${c}\n"
-sudo apt-get install npm python3-pip tar -y
+sudo apt-get install npm python3-pip tar jq -y
 
 printf "${g}[$now] Installing PM2${c}\n"
 npm install pm2 -g && pm2 startup


### PR DESCRIPTION
- Made a API wrapper as a helper to fetch the stream title and game https://github.com/jenslys/twitch-api-wrapper
	- Only downside of this is that the API returns nothing **if the streamer is offline**
- Uses https://stedolan.github.io/jq/ to fetch the json values, so this needs to be installed to be on existing servers. `sudo apt-get install jq`
- adds `STREAM_TITLE` and `STREAM_GAME` as variables to be used in `STREAM_TITLE` for example
	- `API_CALLS` needs to be set to TRUE before using the variables

Related issue/request: https://github.com/jenslys/autovod/issues/17

<hr>

Todo:
- [x] Add jq to install script, docker and readme
- [x] Testing
