### PR TITLE
feat/config changes to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,13 @@ RUN 	tar -xvf youtubeuploader_22.03_Linux_x86_64.tar.gz && rm youtubeuploader_22
 
 # Copy the required files
 
-COPY	${TWITCH_USER}.config /autoVOD/${TWITCH_USER}.config
+COPY	${TWITCH_USER}.config /autoVOD/dockeruser.config
 COPY	AutoVOD.sh /autoVOD/AutoVOD.sh
 COPY	client_secrets.json /autoVOD/client_secrets.json
 COPY	request.token /autoVOD/request.token
 
+
 # Start AutoVod
 
 WORKDIR /autoVOD
-CMD	["bash", "AutoVOD.sh -n $TWITCH_USER"]
+CMD	["bash", "AutoVOD.sh", "-ndockeruser"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.14
 
+#Define an arg variable
+ARG	TWITCH_USER
+
 # Upgrade the system and install dependencies
 
 RUN	apk add --no-cache --upgrade python3 tar wget bash jq
@@ -12,15 +15,12 @@ RUN 	tar -xvf youtubeuploader_22.03_Linux_x86_64.tar.gz && rm youtubeuploader_22
 
 # Copy the required files
 
+COPY	${TWITCH_USER}.config /autoVOD/${TWITCH_USER}.config
 COPY	AutoVOD.sh /autoVOD/AutoVOD.sh
 COPY	client_secrets.json /autoVOD/client_secrets.json
 COPY	request.token /autoVOD/request.token
 
-# Set the environment variable
-ARG	TWITCH_USER
-ENV	TWITCH_USER=$TWITCH_USER
-
 # Start AutoVod
 
 WORKDIR /autoVOD
-CMD	["bash", "AutoVOD.sh"]
+CMD	["bash", "AutoVOD.sh -n $TWITCH_USER"]


### PR DESCRIPTION
Here is the dockerfile working with the new config files. 
The "docker build" command did not change, so no changes to README needed. 
The $TWITCH_STERAMER.config file will be copied to dockeruser.config inside the container, so I dont need to check the name again during runtime of the container, since build-args are only available at build-time.

This is ready for review!