### PR TITLE
Add S3 as an upload provider

### DIFF
--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -29,13 +29,11 @@ STREAMER_NAME=$name
 echo "Selected streamer: $STREAMER_NAME"
 config_file="$STREAMER_NAME.config"
 
-#? Check if requrired files exists
-# The script wont work if these files are missing.
-# So we check if they exists, if not we exit the script.
-if test -f request.token -a -f client_secrets.json -a -f "$config_file"; then
-	echo "All required files exist"
+#? Check if the config exists
+if test -f "$config_file"; then
+	echo "Found config file"
 else
-	echo "One or more required files are missing"
+	echo "Config file is missing"
 	exit 1
 fi
 
@@ -108,6 +106,16 @@ while true; do
 	echo "Checking twitch.tv/"$STREAMER_NAME "for a stream"
 
 	if [ "$UPLOAD_SERVICE" = "youtube" ]; then
+		#? Check if requrired files exists
+		# The script wont work if these files are missing.
+		# So we check if they exists, if not we exit the script.
+		if test -f request.token -a -f client_secrets.json -a -f "$config_file"; then
+			echo "All required files exist"
+		else
+			echo "One or more required files are missing"
+			exit 1
+		fi
+
 		# Create the input file with upload parameters
 		echo '{"title":"'"$VIDEO_TITLE"'","privacyStatus":"'"$VIDEO_VISIBILITY"'","description":"'"$VIDEO_DESCRIPTION"'","playlistTitles":["'"${VIDEO_PLAYLIST}"'"]}' >/tmp/input.$STREAMER_NAME
 

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -40,7 +40,7 @@ while true; do
 		# Src code for this: https://github.com/jenslys/twitch-api-wrapper
 
 		# Store the orignal values
-		variables=("VIDEO_TITLE" "VIDEO_PLAYLIST" "VIDEO_DESCRIPTION")
+		variables=("VIDEO_TITLE" "VIDEO_PLAYLIST" "VIDEO_DESCRIPTION" "S3_OBJECT_KEY")
 		for var in "${variables[@]}"; do
 			original_var=original_$var
 			eval "$original_var=\$$var"

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -34,17 +34,17 @@ source $config_file
 echo ""
 
 while true; do
+	# Store the orignal values
+	variables=("VIDEO_TITLE" "VIDEO_PLAYLIST" "VIDEO_DESCRIPTION" "S3_OBJECT_KEY")
+	for var in "${variables[@]}"; do
+		original_var=original_$var
+		eval "$original_var=\$$var"
+	done
+
 	if [[ "$API_CALLS" == "true" ]]; then
 		#? Fetching stream metadata
 		# Using my own API to wrap around twitch's API to fetch additional stream metadata.
 		# Src code for this: https://github.com/jenslys/twitch-api-wrapper
-
-		# Store the orignal values
-		variables=("VIDEO_TITLE" "VIDEO_PLAYLIST" "VIDEO_DESCRIPTION" "S3_OBJECT_KEY")
-		for var in "${variables[@]}"; do
-			original_var=original_$var
-			eval "$original_var=\$$var"
-		done
 
 		echo "Trying to fetching stream metadata"
 		json=$(curl -s --retry 5 --retry-delay 2 --connect-timeout 30 $API_URL)

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-TIME_DATE='date +%m.%d.%y'
-TIME_CLOCK='date +%H:%M:%S'
+TIME_DATE='date +%m-%d-%y'
+TIME_CLOCK='date +%H_%M_%S'
 
 # Function to get the value of the --name option
 fetch_args() {

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -89,7 +89,7 @@ while true; do
 			CURRENT_PART=1
 		fi
 		# Add " - Part $CURRENT_PART" to the end of the VIDEO_TITLE variable
-		VIDEO_TITLE="$VIDEO_TITLE - Part $CURRENT_PART"
+		VIDEO_TITLE="$VIDEO_TITLE""-""Part_""$CURRENT_PART"
 	fi
 
 	STREAMLINK_OPTIONS="best --hls-duration $VIDEO_DURATION --twitch-disable-hosting --twitch-disable-ads --twitch-disable-reruns -O --loglevel error" # https://streamlink.github.io/cli.html#twitch

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -88,8 +88,9 @@ while true; do
 			# Reset CURRENT_PART to 1 if the current date is not equal to TIME_DATE_CHECK
 			CURRENT_PART=1
 		fi
-		# Add " - Part $CURRENT_PART" to the end of the VIDEO_TITLE variable
+		# Add "-Part_$CURRENT_PART" to the end of the VIDEO_TITLE variable and S3_OBJECT_KEY variable
 		VIDEO_TITLE="$VIDEO_TITLE""-""Part_""$CURRENT_PART"
+		S3_OBJECT_KEY="$S3_OBJECT_KEY""-""Part_""$CURRENT_PART"
 	fi
 
 	STREAMLINK_OPTIONS="best --hls-duration $VIDEO_DURATION --twitch-disable-hosting --twitch-disable-ads --twitch-disable-reruns -O --loglevel error" # https://streamlink.github.io/cli.html#twitch
@@ -117,7 +118,7 @@ while true; do
 		# Then when the stream is finished, uploads the file to S3
 		# https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html
 		streamlink twitch.tv/$STREAMER_NAME $STREAMLINK_OPTIONS -o - >stream.tmp
-		aws s3api put-object --bucket $S3_BUCKET --key $S3_OBJECT_KEY --body stream.tmp --endpoint-url $S3_ENDPOINT_URL >/dev/null 2>&1 && TIME_DATE_CHECK=$($TIME_DATE)
+		aws s3api put-object --bucket $S3_BUCKET --key "$S3_OBJECT_KEY.mkv" --body stream.tmp --endpoint-url $S3_ENDPOINT_URL >/dev/null 2>&1 && TIME_DATE_CHECK=$($TIME_DATE)
 		wait # Wait untill its done uploading before deleting the file
 		rm -f stream.tmp
 	else

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -107,11 +107,21 @@ while true; do
 
 	echo "Checking twitch.tv/"$STREAMER_NAME "for a stream"
 
-	# Create the input file with upload parameters
-	echo '{"title":"'"$VIDEO_TITLE"'","privacyStatus":"'"$VIDEO_VISIBILITY"'","description":"'"$VIDEO_DESCRIPTION"'","playlistTitles":["'"${VIDEO_PLAYLIST}"'"]}' >/tmp/input.$STREAMER_NAME
+	if [ "$UPLOAD_SERVICE" = "youtube" ]; then
+		# Create the input file with upload parameters
+		echo '{"title":"'"$VIDEO_TITLE"'","privacyStatus":"'"$VIDEO_VISIBILITY"'","description":"'"$VIDEO_DESCRIPTION"'","playlistTitles":["'"${VIDEO_PLAYLIST}"'"]}' >/tmp/input.$STREAMER_NAME
 
-	# Pass the stream from streamlink to youtubeuploader and then send the file to the void (dev/null)
-	streamlink twitch.tv/$STREAMER_NAME $STREAMLINK_OPTIONS | youtubeuploader -metaJSON /tmp/input.$STREAMER_NAME -filename - >/dev/null 2>&1 && TIME_DATE_CHECK=$($TIME_DATE)
+		# Pass the stream from streamlink to youtubeuploader and then send the file to the void (dev/null)
+		streamlink twitch.tv/$STREAMER_NAME $STREAMLINK_OPTIONS | youtubeuploader -metaJSON /tmp/input.$STREAMER_NAME -filename - >/dev/null 2>&1 && TIME_DATE_CHECK=$($TIME_DATE)
+	elif [ "$UPLOAD_SERVICE" = "s3" ]; then
+		streamlink twitch.tv/$STREAMER_NAME best -o - >stream.tmp
+		aws s3api put-object --bucket $S3_BUCKET --key $S3_OBJECT_KEY --body stream.tmp --endpoint-url $S3_ENDPOINT_URL >/dev/null 2>&1 && TIME_DATE_CHECK=$($TIME_DATE)
+		wait # Wait untill its done uploading before deleting the file
+		rm -f stream.tmp
+	else
+		echo "Invalid upload service specified: $UPLOAD_SERVICE" >&2
+		exit 1
+	fi
 
 	# Restore the original values
 	for var in "${variables[@]}"; do

--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@
 
 ![Releases](https://img.shields.io/github/v/release/jenslys/AutoVOD.svg)
 
-This script automates downloading and uploading Twitch.TV VODs to either Youtube or an S3 bucket.
-Broadcasts are downloaded in realtime, the best quality available, no transcoding, and sent directly to the selected upload provider, meaning no video is stored on the disk and the stream is directly sent back to the upload provider.
+This script automates downloading and uploading Twitch.TV VODs to a selected upload provider.
+Broadcasts are downloaded in realtime, in the best quality available.
+
+Current available upload providers:
+
+- **Youtube** (Needs no transcoding, so no file is stored on the disc)
+- **S3** (Currently needs transcoding, so the stream is temporally stored on the disc)
 
 The script checks every minute if the selected streamer is live, if the streamer is; it immediately starts uploading the stream. After the stream has eneded, the video gets processed.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 ![Releases](https://img.shields.io/github/v/release/jenslys/AutoVOD.svg)
 
-This script automates downloading and uploading Twitch.TV VODs to Youtube.
-Broadcasts are downloaded in realtime, the best quality available, no transcoding, and sent directly to YouTube, meaning no video is stored on the disk and the stream is directly sent back to YouTube.
+This script automates downloading and uploading Twitch.TV VODs to either Youtube or an S3 bucket.
+Broadcasts are downloaded in realtime, the best quality available, no transcoding, and sent directly to the selected upload provider, meaning no video is stored on the disk and the stream is directly sent back to the upload provider.
 
-The script checks every minute if the selected streamer is live, if the streamer is; it starts immediately uploading the stream to YouTube. After the stream is finished, the video gets processed by YouTube and made public.
+The script checks every minute if the selected streamer is live, if the streamer is; it starts immediately uploading the stream. After the stream is finished, the video gets processed.
 
 ## Table of contents
 
@@ -50,13 +50,29 @@ pip3 install --upgrade streamlink
 apt-get install jq
 ```
 
-#### YouTubeUploader
+#### For Youtube (Optional)
+<details>
+<summary>YoutubeUploader</summary>
+<br>
 
 ```bash
 wget https://github.com/porjo/youtubeuploader/releases/download/22.03/youtubeuploader_22.03_Linux_x86_64.tar.gz
 tar -xvf youtubeuploader_22.03_Linux_x86_64.tar.gz && rm youtubeuploader_22.03_Linux_x86_64.tar.gz
 mv youtubeuploader /usr/local/bin/youtubeuploader
 ```
+</details>
+
+#### For S3 (Optional)
+<details>
+<summary>AWS-CLI</summary>
+<br>
+
+```bash
+apt-get install awscli
+```
+</details>
+
+
 
 #### AutoVOD
 
@@ -78,6 +94,11 @@ I would recommend [Terrahost](https://terrahost.com/virtual-servers) <sub><sup>(
 
 ## Setup
 
+### Youtube setup
+<details>
+<summary>Instructions</summary>
+<br>
+
 Set up your credentials to allow YouTubeUploader to upload videos to YouTube.
 
 1. Create an account on [Google Developers Console](https://console.developers.google.com)
@@ -97,6 +118,8 @@ Set up your credentials to allow YouTubeUploader to upload videos to YouTube.
 
 **Note**
 To be able to upload videos as either "Unlisted or Public" and upload multiple videos a day, you will have to request an [API audit](https://support.google.com/youtube/contact/yt_api_form) from YouTube. Without an audit your videos will be locked as private and you are limited to how many videos you can upload before you reach a quota.
+
+</details>
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ apt-get install awscli
 ```
 </details>
 
-
 #### AutoVOD
 
 ```bash
@@ -127,7 +126,6 @@ Set up your credentials to allow YouTubeUploader to upload videos to YouTube.
 To be able to upload videos as either "Unlisted or Public" and upload multiple videos a day, you will have to request an [API audit](https://support.google.com/youtube/contact/yt_api_form) from YouTube. Without an audit your videos will be locked as private and you are limited to how many videos you can upload before you reach a quota.
 
 </details>
-
 
 ### S3 setup
 
@@ -187,7 +185,7 @@ pm2 logs
 
 ## Using docker
 
-This script can be used inside a docker container. To build a container, first execute all Setup-Steps, then build the image:
+This script can be used inside a docker container. To build a container, first execute all [Setup-Steps](#setup), then build the image:
 
 ```bash
 docker build --build-arg TWITCH_USER=<your twitch username> -t autovod .

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This script automates downloading and uploading Twitch.TV VODs to either Youtube or an S3 bucket.
 Broadcasts are downloaded in realtime, the best quality available, no transcoding, and sent directly to the selected upload provider, meaning no video is stored on the disk and the stream is directly sent back to the upload provider.
 
-The script checks every minute if the selected streamer is live, if the streamer is; it starts immediately uploading the stream. After the stream is finished, the video gets processed.
+The script checks every minute if the selected streamer is live, if the streamer is; it immediately starts uploading the stream. After the stream has eneded, the video gets processed.
 
 ## Table of contents
 
@@ -50,9 +50,12 @@ pip3 install --upgrade streamlink
 apt-get install jq
 ```
 
-#### For Youtube (Optional)
+#### YoutubeUploader
+
+If you want to upload to YouTube
+
 <details>
-<summary>YoutubeUploader</summary>
+<summary>Instructions</summary>
 <br>
 
 ```bash
@@ -62,16 +65,18 @@ mv youtubeuploader /usr/local/bin/youtubeuploader
 ```
 </details>
 
-#### For S3 (Optional)
+#### AWS-CLI
+
+If you want to upload to an S3 Bucket
+
 <details>
-<summary>AWS-CLI</summary>
+<summary>Instrutions</summary>
 <br>
 
 ```bash
 apt-get install awscli
 ```
 </details>
-
 
 
 #### AutoVOD
@@ -88,6 +93,7 @@ wget -c -O sample.mp4 https://download.samplelib.com/mp4/sample-5s.mp4
 ```
 
 #### Note
+
 Daily uploading high quality files/streams to a server may be resource intensive, hence i would recommend using a hosting provider that offers large or unmetered amount of bandwith. Server resource exhaustion may cause vods to fail uploading.
 
 I would recommend [Terrahost](https://terrahost.com/virtual-servers) <sub><sup>(Not sponsored)</sup></sub><br> They offer budget VPS with unmetered* bandwidth.
@@ -95,6 +101,7 @@ I would recommend [Terrahost](https://terrahost.com/virtual-servers) <sub><sup>(
 ## Setup
 
 ### Youtube setup
+
 <details>
 <summary>Instructions</summary>
 <br>
@@ -118,6 +125,24 @@ Set up your credentials to allow YouTubeUploader to upload videos to YouTube.
 
 **Note**
 To be able to upload videos as either "Unlisted or Public" and upload multiple videos a day, you will have to request an [API audit](https://support.google.com/youtube/contact/yt_api_form) from YouTube. Without an audit your videos will be locked as private and you are limited to how many videos you can upload before you reach a quota.
+
+</details>
+
+
+### S3 setup
+
+<details>
+<summary>Instructions</summary>
+
+#### Refer to your S3-Provider on how to configure the AWS-CLI
+
+Common S3 providers:
+
+- [AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/setup-aws-cli.html)
+- [Cloudflare R2](https://developers.cloudflare.com/r2/examples/aws-cli/)
+- [Wasabi S3](https://wasabi-support.zendesk.com/hc/en-us/articles/115001910791-How-do-I-use-AWS-CLI-with-Wasabi-)
+- [Google Cloud Storage](https://developers.cloudflare.com/r2/examples/aws-cli/)
+- [Backblaze B2](https://help.backblaze.com/hc/en-us/articles/360047779633-Quickstart-Guide-for-AWS-CLI-and-Backblaze-B2-Cloud-Storage)
 
 </details>
 

--- a/default.config
+++ b/default.config
@@ -3,7 +3,7 @@
 set -a
 
 #* Upload provider
-UPLOAD_SERVICE="youtube" #* Options: youtube
+UPLOAD_SERVICE="youtube" #* Options: youtube, s3
 
 #* Twitch metadata settings:
 API_CALLS="false"                                                   #? Enable this to fetch additional metadata from the Twitch API.
@@ -20,7 +20,7 @@ STREAMER_GAME="inital_game"    #* The current game the user is playing. (This is
 VIDEO_TITLE="$STREAMER_NAME - $($TIME_DATE)" #? Title of the video / filename.
 VIDEO_DURATION="12:00:00"                    #? XX:XX:XX (Notice: YouTube has a upload limit of 12 hours per video).
 SPLIT_INTO_PARTS="false"                     #? If you want to split the video into parts, set this to true. (if this is enabled VIDEO_DURATION is ignored).
-SPLIT_VIDEO_DURATION="06:00:00"
+SPLIT_VIDEO_DURATION="06:00:00"              #? Set the duration of each part. (XX:XX:XX)
 
 #* YouTube upload settings
 VIDEO_DESCRIPTION="Uploaded using https://github.com/jenslys/AutoVOD" # YouTube video description.

--- a/default.config
+++ b/default.config
@@ -17,7 +17,7 @@ STREAMER_GAME="inital_game"    #* The current game the user is playing. (This is
 #* $($TIME_CLOCK) - The current time (hour:minute:second).
 
 #* Universal Upload settings
-VIDEO_TITLE="$STREAMER_NAME - $($TIME_DATE)" #? Title of the video / filename.
+VIDEO_TITLE="$STREAMER_NAME"_"$($TIME_DATE)" #? Title of the video / filename.
 VIDEO_DURATION="12:00:00"                    #? XX:XX:XX (Notice: YouTube has a upload limit of 12 hours per video).
 SPLIT_INTO_PARTS="false"                     #? If you want to split the video into parts, set this to true. (if this is enabled VIDEO_DURATION is ignored).
 SPLIT_VIDEO_DURATION="06:00:00"              #? Set the duration of each part. (XX:XX:XX)
@@ -30,6 +30,6 @@ VIDEO_PLAYLIST="$STREAMER_NAME VODs"                                  # Playlist
 #* S3 upload settings
 S3_ENDPOINT_URL="https://s3.auto.amazonaws.com"              #? Endpoint URL of the S3 bucket. (e.g: https://s3.auto.amazonaws.com)
 S3_BUCKET="bucket-name"                                      #? S3 bucket to upload to.
-S3_OBJECT_KEY="vods/""$STREAMER_NAME""/""$VIDEO_TITLE"".mkv" #? S3 object key to upload to.
+S3_OBJECT_KEY="vods/""$STREAMER_NAME""/""$VIDEO_TITLE"".mkv" #? S3 object key to upload to. Dont use spaces in the filename, use dashes or undersores instead.
 
 set +a

--- a/default.config
+++ b/default.config
@@ -3,7 +3,7 @@
 set -a
 
 #* Upload provider
-#UPLOAD_SERVICE="youtube" #* Options: youtube
+UPLOAD_SERVICE="youtube" #* Options: youtube
 
 #* Twitch metadata settings:
 API_CALLS="false"                                                   #? Enable this to fetch additional metadata from the Twitch API.
@@ -26,5 +26,10 @@ SPLIT_VIDEO_DURATION="06:00:00"
 VIDEO_DESCRIPTION="Uploaded using https://github.com/jenslys/AutoVOD" # YouTube video description.
 VIDEO_VISIBILITY="unlisted"                                           #* Options: unlisted, private, public
 VIDEO_PLAYLIST="$STREAMER_NAME VODs"                                  # Playlist to upload to.
+
+#* S3 upload settings
+S3_ENDPOINT_URL="https://s3.auto.amazonaws.com"              #? Endpoint URL of the S3 bucket. (e.g: https://s3.auto.amazonaws.com)
+S3_BUCKET="bucket-name"                                      #? S3 bucket to upload to.
+S3_OBJECT_KEY="vods/""$STREAMER_NAME""/""$VIDEO_TITLE"".mkv" #? S3 object key to upload to.
 
 set +a

--- a/default.config
+++ b/default.config
@@ -28,8 +28,8 @@ VIDEO_VISIBILITY="unlisted"                                           #* Options
 VIDEO_PLAYLIST="$STREAMER_NAME VODs"                                  # Playlist to upload to.
 
 #* S3 upload settings
-S3_ENDPOINT_URL="https://s3.auto.amazonaws.com"              #? Endpoint URL of the S3 bucket. (e.g: https://s3.auto.amazonaws.com)
-S3_BUCKET="bucket-name"                                      #? S3 bucket to upload to.
-S3_OBJECT_KEY="vods/""$STREAMER_NAME""/""$VIDEO_TITLE"".mkv" #? S3 object key to upload to. Dont use spaces in the filename, use dashes or undersores instead.
+S3_ENDPOINT_URL="https://s3.auto.amazonaws.com"        #? Endpoint URL of the S3 bucket. (e.g: https://s3.auto.amazonaws.com)
+S3_BUCKET="bucket-name"                                #? S3 bucket to upload to.
+S3_OBJECT_KEY="vods/""$STREAMER_NAME""/""$VIDEO_TITLE" #? S3 object key to upload to. Dont use spaces in the filename, use dashes or undersores instead.
 
 set +a


### PR DESCRIPTION
## Support for uploading to S3.

This PR introduces a new variable in the config file that lets you choose what upload provider you want.
Options:
- Youtube (Default)
- S3

Also adds the necessary variables to be able to upload to S3

**Limitations**:
- Unlike uploading to youtube, I can't find a way to send the stream directly to S3.
so this implementation saves the stream to `stream.tmp` and then uploads it to S3 after the stream is finished


<hr>

### Testing
- I'm using [Cloudflare R2](https://www.cloudflare.com/products/r2/) for testing, but any S3 API-compatible service should work.


### TODO:
- [x] Code comments
- [x] Readme changes
- [x] Testing
- [ ] **Optional**: Re-encoding to AV1? (For smaller file sizes) [May use a lot of computer resources]