### PR TITLE
Re-encoding Stream

### DIFF
--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -118,18 +118,17 @@ while true; do
 		# Then when the stream is finished, uploads the file to S3
 		# https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html
 		temp_file="stream.tmp"
-		temp_file_encoded="stream_encoded.tmp"
-		streamlink twitch.tv/$STREAMER_NAME $STREAMLINK_OPTIONS -o - >$temp_file
 
 		if [ "$RE_ENCODE" == "true" ]; then
 			#? Re-encode the stream before uploading it to S3
 			# This is useful if you want to re-encode the stream to a different codec, quality or file size.
+			# Pipes the stream from streamlink to ffmpeg and then to the temp file
 			# https://ffmpeg.org/ffmpeg.html
+
 			echo "$($CC) Re-encoding stream"
-			ffmpeg -i $temp_file -c:v $RE_ENCODE_CODEC -crf $RE_ENCODE_CRF -hide_banner -loglevel $RE_ENCODE_LOG -f matroska $temp_file_encoded >/dev/null 2>&1
-			wait                         # Wait untill its done encoding before deleting the file
-			rm -f $temp_file             # Delete the original file
-			temp_file=stream_encoded.tmp # Set the temp_file variable to the encoded file
+			streamlink twitch.tv/$STREAMER_NAME $STREAMLINK_OPTIONS --stdout | ffmpeg -i pipe:0 -c:v $RE_ENCODE_CODEC -crf $RE_ENCODE_CRF -hide_banner -loglevel $RE_ENCODE_LOG -f matroska $temp_file >/dev/null 2>&1
+		else
+			streamlink twitch.tv/$STREAMER_NAME $STREAMLINK_OPTIONS -o - >$temp_file
 		fi
 
 		aws s3api put-object --bucket $S3_BUCKET --key "$S3_OBJECT_KEY.mkv" --body $temp_file --endpoint-url $S3_ENDPOINT_URL >/dev/null 2>&1 && TIME_DATE_CHECK=$($TIME_DATE)

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -47,7 +47,7 @@ while true; do
 		# Using my own API to wrap around twitch's API to fetch additional stream metadata.
 		# Src code for this: https://github.com/jenslys/twitch-api-wrapper
 
-		echo "$($CC) Trying to fetching stream metadata"
+		echo "$($CC) Trying to fetch stream metadata"
 		json=$(curl -s --retry 5 --retry-delay 2 --connect-timeout 30 $API_URL)
 		if [ "$json" = "Too many requests, please try again later." ]; then
 			echo "$($CC) $json"
@@ -58,7 +58,7 @@ while true; do
 		fi
 
 		if [ "$STREAMER_TITLE" = null ]; then
-			echo "$($CC) Stream seems offline, can't fetch metadata."
+			echo "$($CC) Stream seems offline, not able to fetch metadata."
 			echo ""
 		else
 			echo "$($CC) Stream is online!"
@@ -122,11 +122,11 @@ while true; do
 		if [ "$RE_ENCODE" == "true" ]; then
 			#? Re-encode the stream before uploading it to S3
 			# This is useful if you want to re-encode the stream to a different codec, quality or file size.
-			# Pipes the stream from streamlink to ffmpeg and then to the temp file
+			# Pipes the stream from streamlink to ffmpeg and then to the matroska temp file
 			# https://ffmpeg.org/ffmpeg.html
 
 			echo "$($CC) Re-encoding stream"
-			streamlink twitch.tv/$STREAMER_NAME $STREAMLINK_OPTIONS --stdout | ffmpeg -i pipe:0 -c:v $RE_ENCODE_CODEC -crf $RE_ENCODE_CRF -hide_banner -loglevel $RE_ENCODE_LOG -f matroska $temp_file >/dev/null 2>&1
+			streamlink twitch.tv/$STREAMER_NAME $STREAMLINK_OPTIONS --stdout | ffmpeg -i pipe:0 -c:v $RE_ENCODE_CODEC -crf $RE_ENCODE_CRF -preset $RE_ECODE_PRESET -hide_banner -loglevel $RE_ENCODE_LOG -f matroska $temp_file >/dev/null 2>&1
 		else
 			streamlink twitch.tv/$STREAMER_NAME $STREAMLINK_OPTIONS -o - >$temp_file
 		fi

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ apt-get install awscli
 
 </details>
 
+#### FFMPEG
+
+If you want to enable the re-encoding feature
+
+<details>
+<summary>Instructions</summary>
+<br>
+
+```bash
+apt-get install ffmpeg
+```
+
+</details>
+
+
 #### AutoVOD
 
 ```bash

--- a/default.config
+++ b/default.config
@@ -37,4 +37,11 @@ S3_ENDPOINT_URL="https://s3.auto.amazonaws.com"        #? Endpoint URL of the S3
 S3_BUCKET="bucket-name"                                #? S3 bucket to upload to.
 S3_OBJECT_KEY="vods/""$STREAMER_NAME""/""$VIDEO_TITLE" #? S3 object key to upload to. Dont use spaces in the filename, use dashes or undersores instead.
 
+#* Re-Encoding settings (Currently only works if UPLOAD_SERVICE is set to s3)
+#? Re-encodes the stream to a desired codec and quality. This can be useful if you want to save space on your S3 bucket. but maybe resource intensive.
+RE_ENCODE="false"         #? Set this to true if you want to re-encode the video.
+RE_ENCODE_CODEC="libx265" #* Options: libx265, libvpx-vp9, libaom-av1 (https://ffmpeg.org/ffmpeg-codecs.html)
+RE_ENCODE_CRF="25"        #* Options: 0-51 (lower is better quality, but larger file size) (https://slhck.info/video/2017/02/24/crf-guide.html)
+RE_ENCODE_LOG="error"     #* Options: none, error, warning, info, debug, trace, all
+
 set +a

--- a/default.config
+++ b/default.config
@@ -17,7 +17,7 @@ STREAMER_GAME="inital_game"    #* The current game the user is playing. (This is
 #* $($TIME_CLOCK) - The current time (hour:minute:second).
 
 #* Streamlink settings
-STREAMLINK_QUALITY="best"                                                                #*Options: worst, 360p, 480p, 720p, best
+STREAMLINK_QUALITY="best"                                                                #* Options: worst, 360p, 480p, 720p, best
 STREAMLINK_FLAGS="--twitch-disable-hosting --twitch-disable-ads --twitch-disable-reruns" #? Options to pass to streamlink. (https://streamlink.github.io/cli.html#twitch)
 STREAMLINK_LOGS="error"                                                                  #* Options: none, error, warning, info, debug, trace, all
 
@@ -42,6 +42,7 @@ S3_OBJECT_KEY="vods/""$STREAMER_NAME""/""$VIDEO_TITLE" #? S3 object key to uploa
 RE_ENCODE="false"         #? Set this to true if you want to re-encode the video.
 RE_ENCODE_CODEC="libx265" #* Options: libx265, libvpx-vp9, libaom-av1 (https://ffmpeg.org/ffmpeg-codecs.html)
 RE_ENCODE_CRF="25"        #* Options: 0-51 (lower is better quality, but larger file size) (https://slhck.info/video/2017/02/24/crf-guide.html)
+RE_ECODE_PRESET="medium"  #* Options: ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow (https://trac.ffmpeg.org/wiki/Encode/H.265)
 RE_ENCODE_LOG="error"     #* Options: none, error, warning, info, debug, trace, all
 
 set +a

--- a/default.config
+++ b/default.config
@@ -38,7 +38,7 @@ S3_BUCKET="bucket-name"                                #? S3 bucket to upload to
 S3_OBJECT_KEY="vods/""$STREAMER_NAME""/""$VIDEO_TITLE" #? S3 object key to upload to. Dont use spaces in the filename, use dashes or undersores instead.
 
 #* Re-Encoding settings (Currently only works if UPLOAD_SERVICE is set to s3)
-#? Re-encodes the stream to a desired codec and quality. This can be useful if you want to save space on your S3 bucket. but maybe resource intensive.
+#? Re-encodes the stream to a desired codec and quality using ffmpeg. This can be useful if you want to save space on your S3 bucket. (Only recommended if you have a high-end server.)
 RE_ENCODE="false"         #? Set this to true if you want to re-encode the video.
 RE_ENCODE_CODEC="libx265" #* Options: libx265, libvpx-vp9, libaom-av1 (https://ffmpeg.org/ffmpeg-codecs.html)
 RE_ENCODE_CRF="25"        #* Options: 0-51 (lower is better quality, but larger file size) (https://slhck.info/video/2017/02/24/crf-guide.html)


### PR DESCRIPTION
Adds optional `RE_ENCODE` variables to the default config that gives you the option to re-encode the stream to a desired codec. Currently only added for the S3 upload provider.

This can be useful if you want to save space on your S3 Bucket

New variables:

```bash
RE_ENCODE="false"         #? Set this to true if you want to re-encode the video.
RE_ENCODE_CODEC="libx265" #* Options: libx265, libvpx-vp9, libaom-av1 (https://ffmpeg.org/ffmpeg-codecs.html)
RE_ENCODE_CRF="25"        #* Options: 0-51 (lower is better quality, but larger file size) (https://slhck.info/video/2017/02/24/crf-guide.html)
RE_ENCODE_LOG="error"     #* Options: none, error, warning, info, debug, trace, all
```


Test sample from before and after Re-encoding:
```
Settings:
1080p60
2 min stream clip
Preset: Medium
Codec: x265
CRF:  25

Output:
Raw output = 122,5 MB
Re-Encoded = 44,02 MB
```