### PR TITLE
use `aws s3 cp` instead of s3api

### DIFF
--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -125,7 +125,8 @@ while true; do
 	elif [ "$UPLOAD_SERVICE" = "s3" ]; then
 		# Saves the stream to a temp file stream.tmp
 		# Then when the stream is finished, uploads the file to S3
-		# https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html
+		# https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html
+
 		temp_file="stream.tmp"
 
 		if [ "$RE_ENCODE" == "true" ]; then
@@ -140,7 +141,7 @@ while true; do
 			streamlink twitch.tv/$STREAMER_NAME $STREAMLINK_OPTIONS -o - >$temp_file
 		fi
 
-		aws s3api put-object --bucket $S3_BUCKET --key "$S3_OBJECT_KEY.mkv" --body $temp_file --endpoint-url $S3_ENDPOINT_URL >/dev/null 2>&1 && TIME_DATE_CHECK=$($TIME_DATE)
+		aws s3 cp $temp_file s3://$S3_BUCKET/$S3_OBJECT_KEY.mkv --expected-size $S3_EXECTED_SIZE --endpoint-url $S3_ENDPOINT_URL >/dev/null 2>&1 && TIME_DATE_CHECK=$($TIME_DATE)
 		wait             # Wait until its done uploading before deleting the file
 		rm -f $temp_file # Delete the temp file
 	elif [ "$UPLOAD_SERVICE" = "reStream" ]; then

--- a/default.config
+++ b/default.config
@@ -37,6 +37,7 @@ VIDEO_PLAYLIST="$STREAMER_NAME VODs"                                  #? Playlis
 S3_ENDPOINT_URL="https://s3.auto.amazonaws.com"        #? Endpoint URL of the S3 bucket. (e.g: https://s3.auto.amazonaws.com)
 S3_BUCKET="bucket-name"                                #? S3 bucket to upload to.
 S3_OBJECT_KEY="vods/""$STREAMER_NAME""/""$VIDEO_TITLE" #? S3 object key to upload to. Dont use spaces in the filename, use dashes or undersores instead.
+S3_EXECTED_SIZE="53687091200"                          #? Expected size of the video in bytes. (Failure to include this argument under these conditions may result in a failed upload due to too many parts in upload.)
 
 #* Re-Stream settings
 RTMPS_URL="rtmp://a.rtmp.youtube.com/live2/"


### PR DESCRIPTION
- Uses [s3 instead of s3api](https://www.learnaws.org/2022/07/07/aws-s3-s3api/#:~:text=your%2Dbucket%2D2-,s3api%20vs%20s3,-Both%20commands%20provide)
- Also adds `S3_EXECTED_SIZE` to the config (in case you upload videos over the standard 50gb limit)