### PR TITLE
Use `mktemp` to create a unique temp-filename

### DIFF
--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -160,7 +160,7 @@ while true; do
 		# then deletes the temp file
 		# https://rclone.org/commands/rclone_copyto/
 
-		TEMP_FILE="stream.tmp"
+		TEMP_FILE=$(mktemp stream.XXXXXX)
 
 		if [ "$RE_ENCODE" == "true" ]; then
 			#? Re-encode the stream before uploading it to rclone

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -190,7 +190,7 @@ while true; do
 			echo "$($CC) rclone failed uploading the stream"
 			if [ "$SAVE_ON_FAIL" == "true" ]; then
 				#? Save the temp file if rclone fails
-				NEW_TEMP_FILE=$(mktemp stream_failed.XXXXXX)
+				NEW_TEMP_FILE=$(mktemp stream_failed_"$STREAMER_NAME".XXXXXX)
 				mv $TEMP_FILE $NEW_TEMP_FILE # Rename the temp file
 				echo "$($CC) Temp file renamed to $NEW_TEMP_FILE"
 			fi

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -224,7 +224,7 @@ while true; do
 				echo "$($CC) Stream re-encoded as $LOCAL_FILENAME"
 			fi
 		else
-			# If you want to save the stream locally to your machine
+			# If you just want to save the stream locally to your machine
 			if ! streamlink twitch.tv/$STREAMER_NAME $STREAMLINK_OPTIONS -o - >"$LOCAL_FILENAME.$LOCAL_EXTENSION"; then
 				echo "$($CC) streamlink failed saving the stream to disk"
 				if [ "$SAVE_ON_FAIL" == "true" ]; then

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -173,6 +173,7 @@ while true; do
 				echo "$($CC) ffmpeg failed re-encoding the stream"
 			fi
 		else
+			# Saves the file to disc to i can be later be uploaded by rclone
 			if ! streamlink twitch.tv/$STREAMER_NAME $STREAMLINK_OPTIONS -o - >$TEMP_FILE; then
 				echo "$($CC) streamlink failed saving the stream to disk"
 			fi

--- a/AutoVOD.sh
+++ b/AutoVOD.sh
@@ -155,7 +155,7 @@ while true; do
 		;;
 
 	"rclone")
-		# Saves the stream to a temp file stream.tmp
+		# Saves the stream to a temp file using mktemp
 		# When the stream is finished, uploads the file to rclone
 		# then deletes the temp file
 		# https://rclone.org/commands/rclone_copyto/

--- a/default.config
+++ b/default.config
@@ -25,7 +25,7 @@ STREAMLINK_LOGS="error"                                                         
 VIDEO_DURATION="12:00:00"       #? XX:XX:XX (Notice: YouTube has a upload limit of 12 hours per video).
 SPLIT_INTO_PARTS="false"        #? If you want to split the video into parts, set this to true. (if this is enabled VIDEO_DURATION is ignored).
 SPLIT_VIDEO_DURATION="06:00:00" #? Set the duration of each part. (XX:XX:XX)
-SAVE_ON_FAIL="false"            #? If you want to save the video if the upload fails, set this to true.
+SAVE_ON_FAIL="false"            #? If you want to save the video that failed to upload, set this to true.
 
 #* YouTube upload settings (Only valid if UPLOAD_SERVICE is set to youtube)
 VIDEO_TITLE="$STREAMER_NAME - $($TIME_DATE)"                          #? Title of the video.

--- a/default.config
+++ b/default.config
@@ -25,6 +25,7 @@ STREAMLINK_LOGS="error"                                                         
 VIDEO_DURATION="12:00:00"       #? XX:XX:XX (Notice: YouTube has a upload limit of 12 hours per video).
 SPLIT_INTO_PARTS="false"        #? If you want to split the video into parts, set this to true. (if this is enabled VIDEO_DURATION is ignored).
 SPLIT_VIDEO_DURATION="06:00:00" #? Set the duration of each part. (XX:XX:XX)
+SAVE_ON_FAIL="false"            #? If you want to save the video if the upload fails, set this to true.
 
 #* YouTube upload settings (Only valid if UPLOAD_SERVICE is set to youtube)
 VIDEO_TITLE="$STREAMER_NAME - $($TIME_DATE)"                          #? Title of the video.


### PR DESCRIPTION
- Replace the hardcoded Tempfile name `stream.tmp` with the built in `mktemp` function to generate a unique name each time. 
	- Sample filename: `stream.QCxlZI`
- Added more prints/echos when something was successful
- Added a new config variable: `SAVE_ON_FAIL` which determines if you want to save the file that for some reason failed to upload.

## Related issues
- closes #66 
- #65 
